### PR TITLE
Fix int

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Rfits
 Type: Package
 Title: FITS Readers and Writers
-Version: 1.8.7
-Date: 2023-05-01
+Version: 1.8.8
+Date: 2023-05-15
 Authors@R: c(
     person(given='Aaron', family='Robotham', email='aaron.robotham@uwa.edu.au',
         role=c('aut', 'cre'), comment=c(ORCID='0000-0003-0429-3579')),

--- a/R/Rfits_image.R
+++ b/R/Rfits_image.R
@@ -175,6 +175,8 @@ Rfits_read_image=function(filename='temp.fits', ext=1, header=TRUE, xlo=NULL, xh
                                            lpixel0=xhi, lpixel1=yhi, lpixel2=zhi, lpixel3=thi,
                                            sparse=sparse)
         
+        check64 = inherits(temp_image, 'integer64')
+        
         if(sparse > 1){
           temp_image = temp_image*sparse^2
         }
@@ -188,6 +190,9 @@ Rfits_read_image=function(filename='temp.fits', ext=1, header=TRUE, xlo=NULL, xh
         }
         if(naxis4 > 1){
           temp_image = array(temp_image, dim=c(floor((xhi - xlo)/sparse) + 1L, floor((yhi - ylo)/sparse) + 1L, floor((zhi - zlo)/sparse) + 1L, floor((thi - tlo)/sparse) + 1L))
+        }
+        if(check64){
+          attributes(temp_image)$class = "integer64"
         }
       })
       if(sparse > 1){

--- a/man/Rfits_methods.Rd
+++ b/man/Rfits_methods.Rd
@@ -227,7 +227,7 @@ Rfits_pixarea(filename, ext=1, useraw=FALSE, unit='asec2', ...)
   \item{collapse}{Logical; should the array or cube be collapsed down dimensions if the 3rd/4th dimensions are 1L? If TRUE this means slices in cubes/arrays are converted to class Rfits_cube/Rfits_image as appropriate.}
   \item{type}{For Rfits_image objects you can specify cutout locations either by pixel position (pix) or RA/Dec coordinates (coord). You will need \code{Rwcs} in the latter case and \option{i} and \option{j} must both be length 1.}
   \item{box}{If \option{i}/\option{j} are length 1 then box[1] and box[2] specifies how big the cutouts will be, where it will be \option{i} +/- (box[1]-1)/2 and \option{j} +/- (box[2]-1)/2}
-  \item{x}{An object of class 'Rfits_pointer'}
+  \item{x}{An object of a relevant class.}
   \item{value}{The replacement data to write to disk.}
   \item{e1}{An object of class 'Rfits_image', where operation happens on e1$imDat}
   \item{e2}{An object of class 'Rfits_image, or a sensible scalar, vector or matrix}

--- a/src/Rfits.cpp
+++ b/src/Rfits.cpp
@@ -588,7 +588,7 @@ SEXP Cfits_read_img(Rcpp::String filename, int ext=1, int datatype= -32,
     std::copy(pixels.begin(), pixels.end(), pixel_matrix.begin());
     return(pixel_matrix);
   }else if (datatype==LONG_IMG){
-    std::vector<long> pixels(nelements);
+    std::vector<uint32_t> pixels(nelements);
     fits_invoke(read_img, fptr, TLONG, 1, nelements, &nullvals, pixels.data(), &anynull);
     Rcpp::IntegerVector pixel_matrix(naxis1 * naxis2 * naxis3 * naxis4);
     std::copy(pixels.begin(), pixels.end(), pixel_matrix.begin());
@@ -750,7 +750,7 @@ SEXP Cfits_read_img_subset(Rcpp::String filename, int ext=1, int datatype= -32,
     std::copy(pixels.begin(), pixels.end(), pixel_matrix.begin());
     return(pixel_matrix);
   }else if (datatype==LONG_IMG){
-    std::vector<long> pixels(nelements);
+    std::vector<uint32_t> pixels(nelements);
     fits_invoke(read_subset, fptr, TLONG, fpixel, lpixel, inc,
                   &nullvals, pixels.data(), &anynull);
     Rcpp::IntegerVector pixel_matrix(nelements);

--- a/src/Rfits.cpp
+++ b/src/Rfits.cpp
@@ -213,9 +213,7 @@ SEXP Cfits_read_col(Rcpp::String filename, int colref=1, int ext=2, long nrow=0)
     long nullval = 0;
     std::vector<long> col(nrow);
     fits_invoke(read_col, fptr, TINT32BIT, colref, 1, 1, nrow, &nullval, col.data(), &anynull);
-    Rcpp::IntegerVector out(nrow);
-    std::copy(col.begin(), col.end(), out.begin());
-    return out;
+    return ensure_lossless_32bit_int(col);
   }
   else if ( typecode == TSHORT ) {
     short nullval = -128;


### PR DESCRIPTION
We now shouldn't have issues with integer overflows of un-signed 32 bit integers (since R only supports signed 32 bit integers). If the values go above 2^31-1 then the class is modified to the bit64 package's integer64 type.