### PR TITLE
Adding packages to remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,11 @@ Authors@R: c(
 Maintainer: Aaron Robotham <aaron.robotham@uwa.edu.au>
 Description: Read and write FITS images, tables and headers.
 License: LGPL-3
-Imports: Rcpp, bit64, checkmate, magicaxis, foreach, doParallel
-Suggests: data.table, testthat, FITSio, Rwcs (>= 1.8.4), tdigest, hdf5r, R.utils, ProFound
+Imports: Rcpp, bit64, checkmate, foreach, doParallel, magicaxis
+Suggests: data.table, testthat, FITSio, hdf5r, ProFound, tdigest, R.utils, Rwcs (>= 1.8.4)
+Remotes:
+  asgr/magicaxis@06eb2e0e98f303ebe2033923ec183be7afd0736a,
+  asgr/Rwcs@master
 Encoding: UTF-8
 LazyData: true
 SystemRequirements: C++11

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: LGPL-3
 Imports: Rcpp, bit64, checkmate, foreach, doParallel, magicaxis
 Suggests: data.table, testthat, FITSio, hdf5r, ProFound, tdigest, R.utils, Rwcs (>= 1.8.4)
 Remotes:
-  asgr/magicaxis@06eb2e0e98f303ebe2033923ec183be7afd0736a,
+  asgr/magicaxis@master,
   asgr/Rwcs@master
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Resolving issue #16. Adding a reference to the GitHub repository of `asgr/magicaxis@master` package (and other remote packages) in the remotes section of the DESCRIPTION. 

On install, the Rfits package should now successfully install all necessary dependencies when running `remotes::install_github("asgr/Rfits")`. 