### PR TITLE
add support for reading tables from

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ Cfits_create_header <- function(filename, create_ext = 1L, create_file = 1L) {
     invisible(.Call(`_Rfits_Cfits_create_header`, filename, create_ext, create_file))
 }
 
-Cfits_read_col <- function(filename, colref = 1L, ext = 2L, nrow = 0L) {
-    .Call(`_Rfits_Cfits_read_col`, filename, colref, ext, nrow)
+Cfits_read_col <- function(filename, colref = 1L, ext = 2L, startrow = 1L, nrow = 0L) {
+    .Call(`_Rfits_Cfits_read_col`, filename, colref, ext, startrow, nrow)
 }
 
 Cfits_read_nrow <- function(filename, ext = 2L) {

--- a/R/Rfits_table.R
+++ b/R/Rfits_table.R
@@ -51,7 +51,7 @@
 #   #define TINT32BIT    41  /* signed 32-bit int,         'J' */
 
 Rfits_read_table=function(filename='temp.fits', ext=2, data.table=TRUE, cols=NULL, verbose=FALSE,
-                          header=FALSE, remove_HIERARCH=FALSE, nrow=0L, zap=NULL, zaptype='full'){
+                          header=FALSE, remove_HIERARCH=FALSE, startrow=1L, nrow=0L, zap=NULL, zaptype='full'){
   assertCharacter(filename, max.len=1)
   filename = path.expand(filename)
   filename = strsplit(filename, '[compress', fixed=TRUE)[[1]][1]
@@ -78,6 +78,8 @@ Rfits_read_table=function(filename='temp.fits', ext=2, data.table=TRUE, cols=NUL
   assertFlag(verbose)
   assertFlag(header)
   assertFlag(remove_HIERARCH)
+  
+  assertInt(startrow, lower = 1L)
 
   output = list()
   count = 1
@@ -87,7 +89,7 @@ Rfits_read_table=function(filename='temp.fits', ext=2, data.table=TRUE, cols=NUL
       message("Reading column: ",colnames[count],", which is ",count," of ", length(cols))
     }
     try({
-      output[[count]] = Cfits_read_col(filename=filename, colref=i, ext=ext, nrow=nrow)
+      output[[count]] = Cfits_read_col(filename=filename, colref=i, ext=ext, startrow=startrow, nrow=nrow)
     })
     if(is.null(output[count][[1]])){
       output[[count]] = NA

--- a/man/Rfits_table.Rd
+++ b/man/Rfits_table.Rd
@@ -12,8 +12,8 @@ Generic table readers and writers. Works with a wide range of data types includi
 }
 \usage{
 Rfits_read_table(filename = 'temp.fits', ext = 2, data.table = TRUE,
-    cols = NULL, verbose = FALSE, header = FALSE, remove_HIERARCH = FALSE, nrow = 0L,
-    zap = NULL, zaptype = 'full')
+    cols = NULL, verbose = FALSE, header = FALSE, remove_HIERARCH = FALSE, startrow = 1L,
+    nrow = 0L, zap = NULL, zaptype = 'full')
 
 Rfits_read_colnames(filename = 'temp.fits', ext = 2)
 
@@ -49,8 +49,11 @@ Logical; if TRUE then output gains attributes containing the header information 
   \item{remove_HIERARCH}{
 Logical, should the leading 'HIERARCH' be removed for extended keyword names (longer than 8 characters)?  
 }
+  \item{startrow}{
+Integer scalar; the 1-based index of the first row from which the FITS table should be read (default is 1). Combined with \code{nrow}, this allows reading a contiguous block of rows starting at \code{startrow} (or to the end if \code{nrow = 0}). This can be useful for chunked reading of large tables.
+}
   \item{nrow}{
-Integer scalar; explicitly specify how many rows to read in. This can be useful just to have a quick look at the top of a file, or if there is something odd about the specified format that means CFITSIO struggles to read the number of rows (e.g. NELEM being used in the header to specify the number of rows).
+Integer scalar; explicitly specify how many rows to read in from \code{startrow}. This can be useful just to have a quick look at the top of a file, or if there is something odd about the specified format that means CFITSIO struggles to read the number of rows (e.g. NELEM being used in the header to specify the number of rows).
 }
   \item{zap}{
 Character vector; optional unique strings to zap out of the header. These elements are passed through code{\link{grep}} one at a time and all matches are removed. This is useful if there a problematic keywords you want to remove when passing raw headers into \code{Rwcs} functions. Be careful that the strings specified are quite unique and do not remove more of the header than intended, e.g. 'CRVAL' would remove all mentions of CRVAL1/2/3 etc. Useful tricks- for inclusive ranges you can use '[]', e.g. 'CD[1-2]_[1-2]' will match to CD1_1, CD1_2, CD2_1, CD2_2. See \code{\link{grep}} for more information on how you pattern match within strings. By default the full 80 character header per key is scanned for matches, but this can be changed with \option{zaptype}.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,16 +23,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // Cfits_read_col
-SEXP Cfits_read_col(Rcpp::String filename, int colref, int ext, long nrow);
-RcppExport SEXP _Rfits_Cfits_read_col(SEXP filenameSEXP, SEXP colrefSEXP, SEXP extSEXP, SEXP nrowSEXP) {
+SEXP Cfits_read_col(Rcpp::String filename, int colref, int ext, long startrow, long nrow);
+RcppExport SEXP _Rfits_Cfits_read_col(SEXP filenameSEXP, SEXP colrefSEXP, SEXP extSEXP, SEXP startrowSEXP, SEXP nrowSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::String >::type filename(filenameSEXP);
     Rcpp::traits::input_parameter< int >::type colref(colrefSEXP);
     Rcpp::traits::input_parameter< int >::type ext(extSEXP);
+    Rcpp::traits::input_parameter< long >::type startrow(startrowSEXP);
     Rcpp::traits::input_parameter< long >::type nrow(nrowSEXP);
-    rcpp_result_gen = Rcpp::wrap(Cfits_read_col(filename, colref, ext, nrow));
+    rcpp_result_gen = Rcpp::wrap(Cfits_read_col(filename, colref, ext, startrow, nrow));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -411,7 +412,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_Rfits_Cfits_create_header", (DL_FUNC) &_Rfits_Cfits_create_header, 3},
-    {"_Rfits_Cfits_read_col", (DL_FUNC) &_Rfits_Cfits_read_col, 4},
+    {"_Rfits_Cfits_read_col", (DL_FUNC) &_Rfits_Cfits_read_col, 5},
     {"_Rfits_Cfits_read_nrow", (DL_FUNC) &_Rfits_Cfits_read_nrow, 2},
     {"_Rfits_Cfits_read_nhdu", (DL_FUNC) &_Rfits_Cfits_read_nhdu, 1},
     {"_Rfits_Cfits_read_ncol", (DL_FUNC) &_Rfits_Cfits_read_ncol, 2},


### PR DESCRIPTION
**What's new**

 - `startrow` argument added to `Cfits_read_col()` and `Rfits_read_table()`
 - Documentation updated for `Rfits_read_table()` (see `startrow` and `nrow`)

**Example**

``` r
file_table <- system.file('extdata', 'table.fits', package = "Rfits")
df <- Rfits::Rfits_read_table(
  file_table,
  ext = 2
)
df2 <- Rfits::Rfits_read_table(
  file_table,
  ext = 2,
  startrow = 3,
  nrow = 5
)
waldo::compare(df[3:7, ], df2)
#> ✔ No differences
```

Closes #19